### PR TITLE
Add copy preserve mode option to control file permission handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -59,8 +59,9 @@ type App struct {
 	lastClickRow   int
 	lastClickTable *tview.Table
 
-	activeDropdown *menu.Dropdown
-	searchTimer    *time.Timer
+	activeDropdown   *menu.Dropdown
+	searchTimer      *time.Timer
+	CopyPreserveMode bool
 }
 
 var Version string
@@ -83,6 +84,7 @@ func New(leftPath, rightPath string) *App {
 	a.LeftPanel.SortMode = panel.SortMode(cfg.LeftPanel.SortMode)
 	a.RightPanel.Mode = panel.DisplayMode(cfg.RightPanel.Mode)
 	a.RightPanel.SortMode = panel.SortMode(cfg.RightPanel.SortMode)
+	a.CopyPreserveMode = cfg.CopyPreserveMode
 	a.LeftPanel.Refresh()
 	a.RightPanel.Refresh()
 
@@ -752,7 +754,7 @@ func (a *App) CopyFiles() {
 			func(entry model.FileEntry) error {
 				srcPath := srcFS.Join(src.Path, entry.Name)
 				dstPath := dstFS.Join(target, entry.Name)
-				return fileops.Copy(context.Background(), srcFS, srcPath, dstFS, dstPath, nil)
+				return fileops.Copy(context.Background(), srcFS, srcPath, dstFS, dstPath, a.CopyPreserveMode, nil)
 			})
 	}, func() {
 		a.closeDialog("input")
@@ -1171,6 +1173,15 @@ func (a *App) showMenuDropdown() {
 	case 2:
 		items = menu.CommandsMenuItems(panelDefs(a.GetActivePanel()))
 	case 3:
+		defs := panelDefs(a.GetActivePanel())
+		defs.CopyPreserveModeOn = a.CopyPreserveMode
+		defs.OnTogglePreserve = func() {
+			a.CopyPreserveMode = !a.CopyPreserveMode
+			a.SaveConfig()
+			a.DeactivateMenu()
+		}
+		items = menu.OptionsMenuItems(defs)
+	case 4:
 		items = menu.RightMenuItems(panelDefs(a.RightPanel))
 	}
 
@@ -1604,6 +1615,7 @@ func (a *App) saveConfigWithServers(cfg *config.Config) {
 	cfg.LeftPanel = config.PanelConfig{Mode: int(a.LeftPanel.Mode), SortMode: int(a.LeftPanel.SortMode), Path: leftPath}
 	cfg.RightPanel = config.PanelConfig{Mode: int(a.RightPanel.Mode), SortMode: int(a.RightPanel.SortMode), Path: rightPath}
 	cfg.ActivePanel = a.activePanel
+	cfg.CopyPreserveMode = a.CopyPreserveMode
 	config.Save(cfg)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,11 +23,12 @@ type ServerConfig struct {
 }
 
 type Config struct {
-	LeftPanel   PanelConfig       `json:"left_panel"`
-	RightPanel  PanelConfig       `json:"right_panel"`
-	ActivePanel int               `json:"active_panel"`
-	Servers     []ServerConfig    `json:"servers,omitempty"`
-	QuickPaths  map[string]string `json:"quick_paths,omitempty"`
+	LeftPanel        PanelConfig       `json:"left_panel"`
+	RightPanel       PanelConfig       `json:"right_panel"`
+	ActivePanel      int               `json:"active_panel"`
+	Servers          []ServerConfig    `json:"servers,omitempty"`
+	QuickPaths       map[string]string `json:"quick_paths,omitempty"`
+	CopyPreserveMode bool             `json:"copy_preserve_mode"`
 }
 
 func configPath() string {

--- a/internal/fileops/copy.go
+++ b/internal/fileops/copy.go
@@ -9,19 +9,21 @@ import (
 )
 
 // Copy recursively copies src to dst, supporting cross-filesystem operations.
-func Copy(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, onProgress func(Progress)) error {
+// When preserveMode is true, the source file/directory permissions are preserved.
+// When false, default permissions are used (0666 for files, 0777 for dirs, modified by umask).
+func Copy(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, preserveMode bool, onProgress func(Progress)) error {
 	srcInfo, err := srcFS.Lstat(src)
 	if err != nil {
 		return fmt.Errorf("stat %s: %w", src, err)
 	}
 
 	if srcInfo.IsDir {
-		return copyDir(ctx, srcFS, src, dstFS, dst, onProgress)
+		return copyDir(ctx, srcFS, src, dstFS, dst, preserveMode, onProgress)
 	}
-	return copyFile(ctx, srcFS, src, dstFS, dst, srcInfo, onProgress)
+	return copyFile(ctx, srcFS, src, dstFS, dst, srcInfo, preserveMode, onProgress)
 }
 
-func copyFile(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, srcInfo vfs.FileInfo, onProgress func(Progress)) error {
+func copyFile(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, srcInfo vfs.FileInfo, preserveMode bool, onProgress func(Progress)) error {
 	// Ensure destination directory exists
 	if err := dstFS.MkdirAll(dstFS.Dir(dst), 0755); err != nil {
 		return err
@@ -33,7 +35,11 @@ func copyFile(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.F
 	}
 	defer sf.Close()
 
-	df, err := dstFS.Create(dst, srcInfo.Mode)
+	mode := srcInfo.Mode
+	if !preserveMode {
+		mode = 0666
+	}
+	df, err := dstFS.Create(dst, mode)
 	if err != nil {
 		return err
 	}
@@ -79,13 +85,17 @@ func copyFile(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.F
 	return nil
 }
 
-func copyDir(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, onProgress func(Progress)) error {
+func copyDir(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileSystem, dst string, preserveMode bool, onProgress func(Progress)) error {
 	srcInfo, err := srcFS.Stat(src)
 	if err != nil {
 		return err
 	}
 
-	if err := dstFS.MkdirAll(dst, srcInfo.Mode); err != nil {
+	dirMode := srcInfo.Mode
+	if !preserveMode {
+		dirMode = 0777
+	}
+	if err := dstFS.MkdirAll(dst, dirMode); err != nil {
 		return err
 	}
 
@@ -102,7 +112,7 @@ func copyDir(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.Fi
 		srcPath := srcFS.Join(src, entry.Name)
 		dstPath := dstFS.Join(dst, entry.Name)
 
-		if err := Copy(ctx, srcFS, srcPath, dstFS, dstPath, onProgress); err != nil {
+		if err := Copy(ctx, srcFS, srcPath, dstFS, dstPath, preserveMode, onProgress); err != nil {
 			return err
 		}
 	}

--- a/internal/fileops/move.go
+++ b/internal/fileops/move.go
@@ -24,7 +24,7 @@ func Move(ctx context.Context, srcFS vfs.FileSystem, src string, dstFS vfs.FileS
 	}
 
 	// Fallback: copy then delete
-	if err := Copy(ctx, srcFS, src, dstFS, dst, onProgress); err != nil {
+	if err := Copy(ctx, srcFS, src, dstFS, dst, true, onProgress); err != nil {
 		// On cancel, clean up partial copy but keep source
 		if ctx.Err() != nil {
 			dstFS.RemoveAll(dst)

--- a/internal/menu/items.go
+++ b/internal/menu/items.go
@@ -24,8 +24,10 @@ type MenuDefs struct {
 	OnCheckUpdate  func()
 	OnSymlink      func()
 	OnChmod        func()
-	OnConnect      func()
-	OnDisconnect   func()
+	OnConnect           func()
+	OnDisconnect        func()
+	OnTogglePreserve    func()
+	CopyPreserveModeOn  bool
 }
 
 func LeftMenuItems(defs *MenuDefs) []MenuItem {
@@ -73,7 +75,13 @@ func CommandsMenuItems(defs *MenuDefs) []MenuItem {
 }
 
 func OptionsMenuItems(defs *MenuDefs) []MenuItem {
-	return []MenuItem{}
+	preserveLabel := "[ ] Copy preserve mode"
+	if defs.CopyPreserveModeOn {
+		preserveLabel = "[x] Copy preserve mode"
+	}
+	return []MenuItem{
+		{Label: preserveLabel, Key: "", Action: defs.OnTogglePreserve, HotKey: 'P'},
+	}
 }
 
 func RightMenuItems(defs *MenuDefs) []MenuItem {

--- a/internal/menu/menubar.go
+++ b/internal/menu/menubar.go
@@ -22,8 +22,8 @@ type MenuBar struct {
 func NewMenuBar() *MenuBar {
 	m := &MenuBar{
 		Box:     tview.NewBox().SetBackgroundColor(theme.ColorMenuBarBg),
-		Items:   []string{" Left ", " File ", " Commands ", " Right "},
-		HotKeys: []rune{'L', 'F', 'C', 'R'},
+		Items:   []string{" Left ", " File ", " Commands ", " Options ", " Right "},
+		HotKeys: []rune{'L', 'F', 'C', 'O', 'R'},
 	}
 	return m
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/feherkaroly/vc/internal/config"
 )
 
-var Version = "3.0.0"
+var Version = "3.0.1"
 
 func main() {
 	showVersion := flag.Bool("version", false, "Show version")


### PR DESCRIPTION
## Summary
This PR adds a configurable "copy preserve mode" option that allows users to control whether file and directory permissions are preserved during copy operations or reset to default values.

## Key Changes
- **File Operations**: Modified `Copy()`, `copyFile()`, and `copyDir()` functions in `internal/fileops/copy.go` to accept a `preserveMode` parameter that controls permission handling:
  - When `true`: source file/directory permissions are preserved
  - When `false`: default permissions are used (0666 for files, 0777 for directories, modified by umask)

- **Configuration**: Added `CopyPreserveMode` field to the `Config` struct in `internal/config/config.go` to persist the user's preference

- **Application State**: Added `CopyPreserveMode` field to the `App` struct in `internal/app/app.go` to track the current setting and pass it to copy operations

- **User Interface**: 
  - Added "Options" menu item to the menu bar in `internal/menu/menubar.go`
  - Implemented `OptionsMenuItems()` in `internal/menu/items.go` with a toggleable "Copy preserve mode" option (hotkey 'P')
  - Added menu callbacks to toggle the setting and persist it to config

- **Move Operations**: Updated `Move()` in `internal/fileops/move.go` to always preserve mode (passes `true`) since move operations should maintain original permissions

## Implementation Details
- The setting is loaded from config on app startup and saved whenever toggled
- The menu displays a checkbox indicator `[x]` or `[ ]` to show the current state
- Default behavior preserves permissions for backward compatibility with move operations

https://claude.ai/code/session_01K7v72iqUMxCyyfJeD5tUZB